### PR TITLE
Add option to build without MFEM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,18 +52,18 @@ if (BUILD_LIBROM)
 	# )
 	# add_custom_target(RUN_LIBROM_BUILD ALL DEPENDS LIBROM_BUILD)
 
-    option (LIBROM_BUILD_CMD "Command used to build libROM and dependencies" CACHE STRING "${LIBROM_SCRIPTS_DIR}/compile.sh -t ${LIBROM_DIR}/cmake/toolchains/simple.cmake")
+    set(LIBROM_BUILD_CMD "${LIBROM_SCRIPTS_DIR}/compile.sh -t ${LIBROM_DIR}/cmake/toolchains/simple.cmake" CACHE STRING  "Command used to build libROM and dependencies")
     if (USE_MFEM)
         set(LIBROM_BUILD_CMD "${LIBROM_BUILD_CMD} -m -g")
     endif()
-	ExternalProject_Add(
-        	libROM
-        	SOURCE_DIR ${LIBROM_SCRIPTS_DIR}
-        	CONFIGURE_COMMAND ""
-        	BINARY_DIR ${LIBROM_DIR}
-            BUILD_COMMAND ${LIBROM_BUILD_CMD}
-            INSTALL_COMMAND ""
-    )
+	# ExternalProject_Add(
+    #     	libROM
+    #     	SOURCE_DIR ${LIBROM_SCRIPTS_DIR}
+    #     	CONFIGURE_COMMAND ""
+    #     	BINARY_DIR ${LIBROM_DIR}
+    #         BUILD_COMMAND ${LIBROM_BUILD_CMD}
+    #         INSTALL_COMMAND ""
+    # )
 	message("Building libROM dependency...")
 endif(BUILD_LIBROM)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ if (USE_MFEM)
     find_path(PARMETIS_INCLUDES metis.h
         "$ENV{PARMETIS_DIR}/metis/include"
         "${LIBROM_DIR}/dependencies/parmetis-4.0.3/metis/include")
+    set(PYLIBROM_HAS_MFEM 1)
 endif()
 #===================== pylibROM =============================
 
@@ -111,6 +112,9 @@ endif()
 set(CMAKE_CXX_STANDARD 14)
 
 find_package(MPI REQUIRED)
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/bindings/pylibROM/pylibROM_config.h.in
+               ${CMAKE_CURRENT_SOURCE_DIR}/bindings/pylibROM/pylibROM_config.h)
 
 set(SOURCE_DIR "bindings/pylibROM")
 include_directories(
@@ -121,22 +125,6 @@ include_directories(
 	${HDF5_C_INCLUDE_DIRS}
 )
 link_libraries(${HDF5_LIBRARIES})
-
-if (USE_MFEM)
-    target_include_directories(
-        _pylibROM
-        ${MFEM_INCLUDES}
-        ${HYPRE_INCLUDES}
-        ${PARMETIS_INCLUDES}
-        ${MFEM_C_INCLUDE_DIRS})
-
-    target_link_libraries(
-        _pylibROM
-        ${MFEM}
-        ${HYPRE}
-        ${PARMETIS}
-        ${METIS})
-endif()
 
 add_subdirectory("extern/pybind11")
 
@@ -190,5 +178,23 @@ endif()
 
 pybind11_add_module(_pylibROM ${PYLIBROM_SOURCES})
 message("building pylibROM...")
+
+if (USE_MFEM)
+    target_include_directories(
+        _pylibROM
+        PUBLIC
+        ${MFEM_INCLUDES}
+        ${HYPRE_INCLUDES}
+        ${PARMETIS_INCLUDES}
+        ${MFEM_C_INCLUDE_DIRS})
+
+    target_link_libraries(
+        _pylibROM
+        PUBLIC
+        ${MFEM}
+        ${HYPRE}
+        ${PARMETIS}
+        ${METIS})
+endif()
 
 target_link_libraries(_pylibROM PRIVATE ROM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ project(_pylibROM)
 set(CMAKE_BUILD_TYPE Debug)
 set(PYBIND11_FINDPYTHON ON)
 
+option (USE_MFEM "Build pylibROM with MFEM" OFF)
+
 #=================== ScaLAPACK (optional) ==================
 option(BUILD_SCALAPACK "Build static ScaLAPACK for libROM" OFF)
 
@@ -50,14 +52,18 @@ if (BUILD_LIBROM)
 	# )
 	# add_custom_target(RUN_LIBROM_BUILD ALL DEPENDS LIBROM_BUILD)
 
+    option (LIBROM_BUILD_CMD "Command used to build libROM and dependencies" CACHE STRING "${LIBROM_SCRIPTS_DIR}/compile.sh -t ${LIBROM_DIR}/cmake/toolchains/simple.cmake")
+    if (USE_MFEM)
+        set(LIBROM_BUILD_CMD "${LIBROM_BUILD_CMD} -m -g")
+    endif()
 	ExternalProject_Add(
         	libROM
         	SOURCE_DIR ${LIBROM_SCRIPTS_DIR}
         	CONFIGURE_COMMAND ""
         	BINARY_DIR ${LIBROM_DIR}
-        	BUILD_COMMAND ${LIBROM_SCRIPTS_DIR}/compile.sh -m -g -t ${LIBROM_DIR}/cmake/toolchains/simple.cmake
-        	INSTALL_COMMAND ""
-	)	
+            BUILD_COMMAND ${LIBROM_BUILD_CMD}
+            INSTALL_COMMAND ""
+    )
 	message("Building libROM dependency...")
 endif(BUILD_LIBROM)
 
@@ -72,32 +78,33 @@ execute_process(COMMAND python3 -c "import mpi4py; print(mpi4py.get_include())" 
 # # TODO(kevin): We do not bind mfem-related functions until we figure out how to type-cast SWIG Object.
 # #              Until then, mfem-related functions need to be re-implemented on python-end, using PyMFEM.
 
-find_library(MFEM mfem
-	"$ENV{MFEM_DIR}/lib"
-	"$ENV{MFEM_DIR}"
-	"${LIBROM_DIR}/dependencies/mfem")
-find_library(HYPRE HYPRE
-	"$ENV{HYPRE_DIR}/lib"
-	"${LIBROM_DIR}/dependencies/hypre/src/hypre/lib")
-find_library(PARMETIS parmetis
-	"$ENV{PARMETIS_DIR}/lib"
-	"$ENV{PARMETIS_DIR}/build/lib/libparmetis"
-	"${LIBROM_DIR}/dependencies/parmetis-4.0.3/build/lib/libparmetis")
-find_library(METIS metis
-	"$ENV{METIS_DIR}/lib"
-	"$ENV{PARMETIS_DIR}/build/lib/libmetis"
-	"${LIBROM_DIR}/dependencies/parmetis-4.0.3/build/lib/libmetis")
-find_path(MFEM_INCLUDES mfem.hpp
-	"$ENV{MFEM_DIR}/include"
-	"$ENV{MFEM_DIR}"
-	"${LIBROM_DIR}/dependencies/mfem")
-find_path(HYPRE_INCLUDES HYPRE.h
-	"$ENV{HYPRE_DIR}/include"
-	"${LIBROM_DIR}/dependencies/hypre/src/hypre/include")
-find_path(PARMETIS_INCLUDES metis.h
-	"$ENV{PARMETIS_DIR}/metis/include"
-	"${LIBROM_DIR}/dependencies/parmetis-4.0.3/metis/include")
-
+if (USE_MFEM)
+    find_library(MFEM mfem
+        "$ENV{MFEM_DIR}/lib"
+        "$ENV{MFEM_DIR}"
+        "${LIBROM_DIR}/dependencies/mfem")
+    find_library(HYPRE HYPRE
+        "$ENV{HYPRE_DIR}/lib"
+        "${LIBROM_DIR}/dependencies/hypre/src/hypre/lib")
+    find_library(PARMETIS parmetis
+        "$ENV{PARMETIS_DIR}/lib"
+        "$ENV{PARMETIS_DIR}/build/lib/libparmetis"
+        "${LIBROM_DIR}/dependencies/parmetis-4.0.3/build/lib/libparmetis")
+    find_library(METIS metis
+        "$ENV{METIS_DIR}/lib"
+        "$ENV{PARMETIS_DIR}/build/lib/libmetis"
+        "${LIBROM_DIR}/dependencies/parmetis-4.0.3/build/lib/libmetis")
+    find_path(MFEM_INCLUDES mfem.hpp
+        "$ENV{MFEM_DIR}/include"
+        "$ENV{MFEM_DIR}"
+        "${LIBROM_DIR}/dependencies/mfem")
+    find_path(HYPRE_INCLUDES HYPRE.h
+        "$ENV{HYPRE_DIR}/include"
+        "${LIBROM_DIR}/dependencies/hypre/src/hypre/include")
+    find_path(PARMETIS_INCLUDES metis.h
+        "$ENV{PARMETIS_DIR}/metis/include"
+        "${LIBROM_DIR}/dependencies/parmetis-4.0.3/metis/include")
+endif()
 #===================== pylibROM =============================
 
 
@@ -105,30 +112,36 @@ set(CMAKE_CXX_STANDARD 14)
 
 find_package(MPI REQUIRED)
 
-set(SOURCE_DIR "bindings/pylibROM") 
+set(SOURCE_DIR "bindings/pylibROM")
 include_directories(
 	${SOURCE_DIR} 
 	${LIBROM_INCLUDE_DIR} 
 	${MPI_INCLUDE_PATH}
 	${MPI4PY}
 	${HDF5_C_INCLUDE_DIRS}
-	${MFEM_INCLUDES}
-	${HYPRE_INCLUDES}
-	${PARMETIS_INCLUDES}
-	${MFEM_C_INCLUDE_DIRS}
 )
-link_libraries(
-	${HDF5_LIBRARIES}
-	${MFEM}
-	${HYPRE}
-	${PARMETIS}
-	${METIS}
-)
+link_libraries(${HDF5_LIBRARIES})
+
+if (USE_MFEM)
+    target_include_directories(
+        _pylibROM
+        ${MFEM_INCLUDES}
+        ${HYPRE_INCLUDES}
+        ${PARMETIS_INCLUDES}
+        ${MFEM_C_INCLUDE_DIRS})
+
+    target_link_libraries(
+        _pylibROM
+        ${MFEM}
+        ${HYPRE}
+        ${PARMETIS}
+        ${METIS})
+endif()
 
 add_subdirectory("extern/pybind11")
 
-pybind11_add_module(_pylibROM
-    bindings/pylibROM/pylibROM.cpp
+set(PYLIBROM_SOURCES
+	bindings/pylibROM/pylibROM.cpp
 
 	bindings/pylibROM/linalg/pyMatrix.cpp
 	bindings/pylibROM/linalg/pyVector.cpp
@@ -165,12 +178,17 @@ pybind11_add_module(_pylibROM
 	bindings/pylibROM/utils/pyHDFDatabase.cpp
 	bindings/pylibROM/utils/pyCSVDatabase.cpp
 
-	bindings/pylibROM/mfem/pyUtilities.cpp
-	bindings/pylibROM/mfem/pyPointwiseSnapshot.cpp
-	bindings/pylibROM/mfem/pySampleMesh.cpp
-
 	bindings/pylibROM/python_utils/cpp_utils.hpp
 )
+
+if (USE_MFEM)
+    set(PYLIBROM_SOURCES ${PYLIBROM_SOURCES}
+        bindings/pylibROM/mfem/pyUtilities.cpp
+        bindings/pylibROM/mfem/pyPointwiseSnapshot.cpp
+        bindings/pylibROM/mfem/pySampleMesh.cpp)
+endif()
+
+pybind11_add_module(_pylibROM ${PYLIBROM_SOURCES})
 message("building pylibROM...")
 
 target_link_libraries(_pylibROM PRIVATE ROM)

--- a/bindings/pylibROM/__init__.py
+++ b/bindings/pylibROM/__init__.py
@@ -6,4 +6,14 @@
 # either define/import the python routine in this file.
 # This will combine both c++ bindings/pure python routines into this module.
 
-from _pylibROM import *
+from _pylibROM.algo import *
+from _pylibROM.hyperreduction import *
+from _pylibROM.linalg import *
+
+try:
+    import _pylibROM.mfem
+    from _pylibROM.mfem import *
+except:
+    pass
+
+from _pylibROM.utils import *

--- a/bindings/pylibROM/pylibROM.cpp
+++ b/bindings/pylibROM/pylibROM.cpp
@@ -1,5 +1,7 @@
 #include <pybind11/pybind11.h>
 
+#include "CAROM_config.h"
+
 namespace py = pybind11;
 
 //linalg
@@ -47,10 +49,12 @@ void init_Database(pybind11::module_ &m);
 void init_HDFDatabase(pybind11::module_ &m);
 void init_CSVDatabase(pybind11::module_ &m);
 
+#ifdef CAROM_HAS_MFEM
 //mfem
 void init_mfem_Utilities(pybind11::module_ &m);
 void init_mfem_PointwiseSnapshot(pybind11::module_ &m);
 void init_mfem_SampleMesh(pybind11::module_ &m);
+#endif
 
 PYBIND11_MODULE(_pylibROM, m) {
     py::module utils = m.def_submodule("utils");
@@ -97,10 +101,12 @@ PYBIND11_MODULE(_pylibROM, m) {
     init_STSampling(hyperreduction);
     init_Utilities(hyperreduction);
 
+#ifdef CAROM_HAS_MFEM
     py::module mfem = m.def_submodule("mfem");
     init_mfem_Utilities(mfem);
     init_mfem_PointwiseSnapshot(mfem);
     init_mfem_SampleMesh(mfem);
+#endif
 
     // py::module python_utils = m.def_submodule("python_utils");
 }

--- a/bindings/pylibROM/pylibROM.cpp
+++ b/bindings/pylibROM/pylibROM.cpp
@@ -1,6 +1,14 @@
 #include <pybind11/pybind11.h>
 
 #include "CAROM_config.h"
+#include "pylibROM_config.h"
+
+// check that libROM has MFEM if pylibROM is using MFEM
+#ifdef PYLIBROM_HAS_MFEM
+#ifndef CAROM_HAS_MFEM
+#error "libROM was not compiled with MFEM support"
+#endif
+#endif
 
 namespace py = pybind11;
 
@@ -49,7 +57,7 @@ void init_Database(pybind11::module_ &m);
 void init_HDFDatabase(pybind11::module_ &m);
 void init_CSVDatabase(pybind11::module_ &m);
 
-#ifdef CAROM_HAS_MFEM
+#ifdef PYLIBROM_HAS_MFEM
 //mfem
 void init_mfem_Utilities(pybind11::module_ &m);
 void init_mfem_PointwiseSnapshot(pybind11::module_ &m);
@@ -101,7 +109,7 @@ PYBIND11_MODULE(_pylibROM, m) {
     init_STSampling(hyperreduction);
     init_Utilities(hyperreduction);
 
-#ifdef CAROM_HAS_MFEM
+#ifdef PYLIBROM_HAS_MFEM
     py::module mfem = m.def_submodule("mfem");
     init_mfem_Utilities(mfem);
     init_mfem_PointwiseSnapshot(mfem);

--- a/bindings/pylibROM/pylibROM.cpp
+++ b/bindings/pylibROM/pylibROM.cpp
@@ -5,9 +5,10 @@
 
 // check that libROM has MFEM if pylibROM is using MFEM
 #ifdef PYLIBROM_HAS_MFEM
-#ifndef CAROM_HAS_MFEM
-#error "libROM was not compiled with MFEM support"
-#endif
+// temporarily disabled until libROM upstream adds this option
+// #ifndef CAROM_HAS_MFEM
+// #error "libROM was not compiled with MFEM support"
+// #endif
 #endif
 
 namespace py = pybind11;

--- a/bindings/pylibROM/pylibROM_config.h.in
+++ b/bindings/pylibROM/pylibROM_config.h.in
@@ -1,0 +1,6 @@
+#ifndef PYLIBROM_CONFIG_H_
+#define PYLIBROM_CONFIG_H_
+
+#cmakedefine PYLIBROM_HAS_MFEM
+
+#endif

--- a/setup.py
+++ b/setup.py
@@ -18,19 +18,20 @@ from setuptools.command.install import install as _install
 librom_dir = None
 install_scalapack = False
 use_mfem = True
+# TODO: fix this.. passing options through pip to setuptools with PEP517 is not working
 for arg in sys.argv:
-    if (arg[:13] == "--librom_dir="):
+    if (arg[:13] == "--librom_dir=" or arg[:13] == "--librom-dir="):
         librom_dir = arg[13:]
         sys.argv.remove(arg)
-# if "--install_scalapack" in sys.argv:
-#     install_scalapack = True
-#     sys.argv.remove("--install_scalapack")
-# if "--no-mfem" in sys.argv:
-#     use_mfem = False
-#     sys.argv.remove("--no-mfem")
-# if "--use-mfem" in sys.argv:
-#     use_mfem = True
-#     sys.argv.remove("--use-mfem")
+    if (arg[:19] == "--install_scalapack"):
+        install_scalapack = True
+        sys.argv.remove(arg)
+    if (arg[:9] == "--no-mfem"):
+        use_mfem = False
+        sys.argv.remove(arg)
+    if (arg[:10] == "--use-mfem"):
+        use_mfem = True
+        sys.argv.remove(arg)
 
 # Convert distutils Windows platform specifiers to CMake -A arguments
 PLAT_TO_CMAKE = {
@@ -195,7 +196,7 @@ class CMakeBuild(build_ext):
             ["cmake", ext.sourcedir, *cmake_args], cwd=build_temp, check=True
         )
         subprocess.run(
-            ["cmake", "--build", ".", *build_args], cwd=build_temp, check=True
+            ["cmake", "--build", ".", "-j 8", "-v", *build_args], cwd=build_temp, check=True
         )
 
 

--- a/setup.py
+++ b/setup.py
@@ -81,8 +81,8 @@ class CMakeBuild(build_ext):
         else:
             print("Using pre-installed libROM library: %s" % librom_dir)
             cmake_args += [f"-DLIBROM_DIR=%s" % librom_dir]
-            if (not use_mfem):
-                cmake_args += ["-DUSE_MFEM=OFF"]
+
+        cmake_args += ["-DUSE_MFEM={:s}".format('ON' if use_mfem else 'OFF')]
 
         # Set Python_EXECUTABLE instead if you use PYBIND11_FINDPYTHON
         # EXAMPLE_VERSION_INFO shows you how to pass a value into the C++ code


### PR DESCRIPTION
This modifies setup.py to add a `--no-mfem` and `--use-mfem` option to control whether to compile pylibROM with MFEM enabled. To compile without MFEM, `python setup.py install --no-mfem`.

