### PR TITLE
Fix matrix bindings for distributed matrices

### DIFF
--- a/bindings/pylibROM/linalg/pyMatrix.cpp
+++ b/bindings/pylibROM/linalg/pyMatrix.cpp
@@ -84,7 +84,7 @@ void init_matrix(pybind11::module_ &m) {
         .def("getFirstNColumns", (void (Matrix::*)(int, Matrix&) const) &Matrix::getFirstNColumns)
         
         .def("mult",[](const Matrix& self, const Matrix& other){
-             Matrix* result = new Matrix();
+             Matrix* result = nullptr;
              self.mult(other,result);
              return result; 
         },py::return_value_policy::take_ownership)
@@ -94,7 +94,7 @@ void init_matrix(pybind11::module_ &m) {
         })
         .def("mult", (void (Matrix::*)(const Matrix&, Matrix&) const) &Matrix::mult)
         .def("mult", [](Matrix& self, const Vector& other){
-             Vector* result = new Vector();
+             Vector* result = nullptr;
              self.mult(other,result);
              return result; 
         }, py::return_value_policy::take_ownership)
@@ -112,7 +112,7 @@ void init_matrix(pybind11::module_ &m) {
             })
 
         .def("elementwise_mult",[](const Matrix& self, const Matrix& other) {
-                Matrix* result = new Matrix();
+                Matrix* result = nullptr;
                 self.elementwise_mult(other, result);
                 return result;
             }, py::return_value_policy::take_ownership)
@@ -123,7 +123,7 @@ void init_matrix(pybind11::module_ &m) {
         .def("elementwise_mult",(void (Matrix::*)(const Matrix&,Matrix&) const) &Matrix::elementwise_mult)
         
         .def("elementwise_square",[](const Matrix& self) {
-                Matrix* result = new Matrix();
+                Matrix* result = nullptr;
                 self.elementwise_square(result);
                 return result;
             },py::return_value_policy::take_ownership)
@@ -135,7 +135,7 @@ void init_matrix(pybind11::module_ &m) {
         .def("multPlus", (void (Matrix::*)(Vector&,const Vector&,double) const) &Matrix::multPlus)
 
         .def("transposeMult",[](const Matrix& self, const Matrix& other) {
-                 Matrix* result = new Matrix();
+                 Matrix* result = nullptr;
                  self.transposeMult(other, result);
                  return result;
              },py::return_value_policy::take_ownership)
@@ -145,7 +145,7 @@ void init_matrix(pybind11::module_ &m) {
         })
         .def("transposeMult", (void (Matrix::*)(const Matrix&, Matrix&) const) &Matrix::transposeMult)
         .def("transposeMult",[](const Matrix& self, const Vector& other) {
-                 Vector* result = new Vector();
+                 Vector* result = nullptr;
                  self.transposeMult(other, result);
                  return result;
              },py::return_value_policy::take_ownership)


### PR DESCRIPTION
This fixes some overloads for the Matrix class when used with distributed matrices or vectors.

For example, the following example would fail when A and C are pre-defined and distributed:
```
import numpy as np
import pylibROM.linalg as linalg

A = linalg.Matrix(5, 3, True)
A[0,0] = 1.; A[1,1] = 1.; A[2,2] = 1.
B = linalg.Matrix(3, 5, False)
B[0,0] = 1.; B[1,1] = 1.; B[2,2] = 1.
C = linalg.Matrix(3,3,True)
C = A.mult(B)
```

However, the `A.mult(B, C)` variation of this worked as expected. Bindings for other Matrix functions using similar syntax to `C = A.mult(B)` with distributed inputs are now fixed.